### PR TITLE
Updating to use Quorum 2.0.2 and Constellation 0.3.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM ubuntu:16.04 as builder
 
+ARG CONSTELLATION_VERSION=0.3.2
+ARG QUORUM_VERSION=2.0.2
+
 WORKDIR /work
 
 RUN apt-get update && \
@@ -15,13 +18,11 @@ RUN apt-get update && \
             wrk \
             zlib1g-dev
 
-RUN wget -q https://github.com/jpmorganchase/constellation/releases/download/v0.0.1-alpha/ubuntu1604.zip && \
-    unzip ubuntu1604.zip && \
-    cp ubuntu1604/constellation-node /usr/local/bin && \
+RUN wget -q https://github.com/jpmorganchase/constellation/releases/download/v$CONSTELLATION_VERSION/constellation-$CONSTELLATION_VERSION-ubuntu1604.tar.xz && \
+    tar -xvf constellation-$CONSTELLATION_VERSION-ubuntu1604.tar.xz && \
+    cp constellation-$CONSTELLATION_VERSION-ubuntu1604/constellation-node /usr/local/bin && \
     chmod 0755 /usr/local/bin/constellation-node && \
-    cp ubuntu1604/constellation-enclave-keygen /usr/local/bin/ && \
-    chmod 0755 /usr/local/bin/constellation-enclave-keygen && \
-    rm -rf ubuntu1604.zip ubuntu1604
+    rm -rf constellation-$CONSTELLATION_VERSION-ubuntu1604.tar.xz constellation-$CONSTELLATION_VERSION-ubuntu1604
 
 ENV GOREL go1.7.3.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin
@@ -33,7 +34,7 @@ RUN wget -q https://storage.googleapis.com/golang/$GOREL && \
 
 RUN git clone https://github.com/jpmorganchase/quorum.git && \
     cd quorum && \
-    git checkout tags/v1.2.0 && \
+    git checkout tags/v$QUORUM_VERSION && \
     make all && \
     cp build/bin/geth /usr/local/bin && \
     cp build/bin/bootnode /usr/local/bin && \
@@ -51,7 +52,9 @@ RUN apt-get update && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
         libdb-dev \
+        libleveldb-dev \
         libsodium-dev \
+        zlib1g-dev\
         libtinfo-dev \
         solc && \
     rm -rf /var/lib/apt/lists/*
@@ -62,7 +65,6 @@ RUN apt-get update && \
 
 COPY --from=builder \
         /usr/local/bin/constellation-node \
-        /usr/local/bin/constellation-enclave-keygen \
         /usr/local/bin/geth \
         /usr/local/bin/bootnode \
     /usr/local/bin/

--- a/Nnodes/setup.sh
+++ b/Nnodes/setup.sh
@@ -69,11 +69,12 @@ do
     qd=qdata_$n
 
     # Generate the node's Enode and key
-    enode=`docker run -u $uid:$gid -v $pwd/$qd:/qdata $image /usr/local/bin/bootnode -genkey /qdata/dd/nodekey -writeaddress`
+    enode=`docker run -u $uid:$gid -v $pwd/$qd:/qdata $image sh -c "/usr/local/bin/bootnode -genkey /qdata/dd/nodekey -writeaddress; cat /qdata/dd/nodekey"`
+    enode=`docker run -u $uid:$gid -v $pwd/$qd:/qdata $image sh -c "/usr/local/bin/bootnode -nodekeyhex $enode -writeaddress"`
 
     # Add the enode to static-nodes.json
     sep=`[[ $n < $nnodes ]] && echo ","`
-    echo '  "enode://'$enode'@'$ip':30303?discport=0"'$sep >> static-nodes.json
+    echo '  "enode://'$enode'@'$ip':30303?raftport=50400"'$sep >> static-nodes.json
 
     let n++
 done
@@ -156,7 +157,7 @@ do
     cp static-nodes.json $qd/dd/static-nodes.json
 
     # Generate Quorum-related keys (used by Constellation)
-    docker run -u $uid:$gid -v $pwd/$qd:/qdata $image /usr/local/bin/constellation-enclave-keygen /qdata/keys/tm /qdata/keys/tma < /dev/null > /dev/null
+    docker run -u $uid:$gid -v $pwd/$qd:/qdata $image /usr/local/bin/constellation-node --generatekeys=/qdata/keys/tm < /dev/null > /dev/null
     echo 'Node '$n' public key: '`cat $qd/keys/tm.pub`
 
     cp templates/start-node.sh $qd/start-node.sh
@@ -189,6 +190,7 @@ do
         ipv4_address: '$ip'
     ports:
       - $((n+22000)):8545
+      - $((n+27000)):9000
     user: '$uid:$gid'
 EOF
 

--- a/Nnodes/templates/tm.conf
+++ b/Nnodes/templates/tm.conf
@@ -1,9 +1,8 @@
 url = "http://_NODEIP_:9000/"
 port = 9000
-socketPath = "/qdata/tm.ipc"
-otherNodeUrls = [_NODELIST_]
-publicKeyPath = "/qdata/keys/tm.pub"
-privateKeyPath = "/qdata/keys/tm.key"
-archivalPublicKeyPath = "/qdata/keys/tma.pub"
-archivalPrivateKeyPath = "/qdata/keys/tma.key"
-storagePath = "/qdata/constellation"
+socket = "tm.ipc"
+othernodes = [_NODELIST_]
+publickeys = ["/qdata/keys/tm.pub"]
+privatekeys = ["/qdata/keys/tm.key"]
+workdir = "/qdata/constellation"
+tls = "off"


### PR DESCRIPTION
A few changes to adapt the docker image and setup script to use Quorum 2.0.2 and Constellation 0.3.2.

There are some features on Geth that were removed. The one that affects the examples is that it is not possible to compile a contract via the API (`loadScript("contract_pub.js")` doesn't work anymore).